### PR TITLE
Updating permissions on rank change

### DIFF
--- a/views/core/editStaff.php
+++ b/views/core/editStaff.php
@@ -10,7 +10,9 @@ if ($result_of_query->num_rows > 0) {
             $staffName = $_POST['staffName'];
             $staffEmail = $_POST['staffEmail'];
             $staffPID = $_POST['staffPID'];
+            $permissions = include 'config/permissions.php';
             if (isset($_POST['ban'])) $staffRank = 0; else $staffRank = $_POST['staffRank'];
+	    $userPerms = json_encode($permissions[$staffRank]);
 	
             $sql = "UPDATE `users` SET `user_name`='" . $staffName . "',`user_email`='" . $staffEmail . "',`playerid`='" . $staffPID . "',`user_level`='" . $staffRank . "' WHERE `user_id` ='" . $uId . "';";
             $result_of_query = $db_connection->query($sql);


### PR DESCRIPTION
Currently, when editing staff, the permissions don't change when a users rank is changed. E.g, if you changed someone from Super Admin to Player, they would retain the Super Admin permissions. I'm not sure if this has been overlooked or not as it seems to be a crucial thing. By no means have I done this the best way, my PHP knowledge is minimal, this was just a hot fix for me.
