### PR TITLE
Updating permissions on rank change / editVeh minor fixes

### DIFF
--- a/views/core/editStaff.php
+++ b/views/core/editStaff.php
@@ -14,7 +14,7 @@ if ($result_of_query->num_rows > 0) {
             if (isset($_POST['ban'])) $staffRank = 0; else $staffRank = $_POST['staffRank'];
 	    $userPerms = json_encode($permissions[$staffRank]);
 	
-            $sql = "UPDATE `users` SET `user_name`='" . $staffName . "',`user_email`='" . $staffEmail . "',`playerid`='" . $staffPID . "',`user_level`='" . $staffRank . "' WHERE `user_id` ='" . $uId . "';";
+            $sql = "UPDATE `users` SET `user_name`='" . $staffName . "',`user_email`='" . $staffEmail . "',`playerid`='" . $staffPID . "',`user_level`='" . $staffRank . "', `permissions`='" . $userPerms . "' WHERE `user_id` ='" . $uId . "';";
             $result_of_query = $db_connection->query($sql);
             message(ucfirst($_POST['staffName']) . ' ' . $lang['updated']);
         } else message($lang['expired']);

--- a/views/core/editStaff.php
+++ b/views/core/editStaff.php
@@ -10,7 +10,9 @@ if ($result_of_query->num_rows > 0) {
             $staffName = $_POST['staffName'];
             $staffEmail = $_POST['staffEmail'];
             $staffPID = $_POST['staffPID'];
+            $permissions = include 'config/permissions.php';
             if (isset($_POST['ban'])) $staffRank = 0; else $staffRank = $_POST['staffRank'];
+	    $userPerms = json_encode($permissions[$staffRank]);
 	
             $sql = "UPDATE `users` SET `user_name`='" . $staffName . "',`user_email`='" . $staffEmail . "',`playerid`='" . $staffPID . "',`user_level`='" . $staffRank . "' WHERE `user_id` ='" . $uId . "';";
             $result_of_query = $db_connection->query($sql);

--- a/views/life/editVeh.php
+++ b/views/life/editVeh.php
@@ -94,9 +94,9 @@ if ($result_of_query->num_rows > 0) {
             }
 
             if ($veh->active == false) {
-                echo " <span class='label label-danger'>" . $lang["not"] . " " . $lang["active"] . "</span></h4>";
+                echo " <h4><span class='label label-danger'>" . $lang["not"] . " " . $lang["active"] . "</span></h4>";
             } else {
-                echo " <span class='label label-success'>" . $lang["active"] . "</span></h4>";
+                echo " <h4><span class='label label-success'>" . $lang["active"] . "</span></h4>";
             }
             if ($_SESSION['permissions']['edit']['vehicles']) {
                 echo '
@@ -222,7 +222,7 @@ if ($result_of_query->num_rows > 0) {
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                     <h4 class="modal-title"><span
-                            class="glyphicon glyphicon-pencil"></span><?php echo " " . $lang['DELETE'] . " " . $lang['vehicle']; ?>
+                            class="glyphicon glyphicon-pencil"></span><?php echo " " . $lang['delete'] . " " . $lang['vehicle']; ?>
                     </h4>
                 </div>
                 <?php  echo '<form method="post" action="' . $settings['url'] . 'editVeh/' . $vehID . '">' ?>


### PR DESCRIPTION
Currently, when editing staff, the permissions don't change when a users rank is changed. E.g, if you changed someone from Super Admin to Player, they would retain the Super Admin permissions. I'm not sure if this has been overlooked or not as it seems to be a crucial thing. By no means have I done this the best way, my PHP knowledge is minimal, this was just a hot fix for me.

Also fixed a few minor things in editVeh, the notes are in the commit.
